### PR TITLE
feat(utils): add --yolo flag to skip permissions

### DIFF
--- a/utils/claude-plus.sh
+++ b/utils/claude-plus.sh
@@ -101,6 +101,10 @@ while [[ $# -gt 0 ]]; do
       memory_enabled="$2"
       shift 2
       ;;
+    --yolo)
+      args+=("--dangerously-skip-permissions")
+      shift
+      ;;
     -h|--help)
       show_help
       exit 0


### PR DESCRIPTION
Add --yolo flag to claude-plus.sh wrapper that passes --dangerously-skip-permissions to the underlying CLI. This provides a convenient shorthand for bypassing permission prompts during development workflows.